### PR TITLE
Adjusting inactivity timeout to keep-alive signal

### DIFF
--- a/lib/gnip-stream/stream.rb
+++ b/lib/gnip-stream/stream.rb
@@ -28,7 +28,7 @@ module GnipStream
 
     def connect
       EM.run do
-        http = EM::HttpRequest.new(@url, :inactivity_timeout => 2**16, :connection_timeout => 2**16).get(:head => @headers)
+        http = EM::HttpRequest.new(@url, :inactivity_timeout => 45, :connection_timeout => 75).get(:head => @headers)
         http.stream { |chunk| process_chunk(chunk) }
         http.callback { 
           handle_connection_close(http) 


### PR DESCRIPTION
Gnip sends a keep-alive signal each 30 seconds, so it is recommended that the stream reconnects if it takes longer than that to receive the signal.