### PR TITLE
Fixed: Json parser was not capturing multiple activities in a single chunk

### DIFF
--- a/lib/gnip-stream.rb
+++ b/lib/gnip-stream.rb
@@ -1,9 +1,10 @@
 require "gnip-stream/version"
 
 require 'gnip-stream/stream'
-require 'gnip-stream/data_buffer'
 require 'gnip-stream/json_stream'
+require 'gnip-stream/json_data_buffer'
 require 'gnip-stream/xml_stream'
+require 'gnip-stream/xml_data_buffer'
 require 'gnip-stream/powertrack_client'
 require 'gnip-stream/facebook_client'
 require 'gnip-stream/error_reconnect'

--- a/lib/gnip-stream/json_data_buffer.rb
+++ b/lib/gnip-stream/json_data_buffer.rb
@@ -1,0 +1,25 @@
+module GnipStream
+  class JsonDataBuffer 
+    attr_accessor :split_pattern, :check_pattern
+    def initialize(split_pattern, check_pattern)
+      @split_pattern = split_pattern
+      @check_pattern = check_pattern
+      @buffer = ""
+    end
+
+    def process(chunk)
+      @buffer.concat(chunk)
+    end
+
+    def complete_entries
+      entries = []
+      while @buffer =~ check_pattern
+        activities = @buffer.split(split_pattern)
+        entries << activities.shift
+        @buffer = activities.join('')
+      end
+
+      entries
+    end
+  end
+end

--- a/lib/gnip-stream/json_data_buffer.rb
+++ b/lib/gnip-stream/json_data_buffer.rb
@@ -16,7 +16,7 @@ module GnipStream
       while @buffer =~ check_pattern
         activities = @buffer.split(split_pattern)
         entries << activities.shift
-        @buffer = activities.join('')
+        @buffer = activities.join(split_pattern)
       end
 
       entries

--- a/lib/gnip-stream/json_stream.rb
+++ b/lib/gnip-stream/json_stream.rb
@@ -4,7 +4,7 @@ module GnipStream
   class JsonStream
     include StreamDelegate
     def initialize(url, headers={})
-      json_processor = JsonDataBuffer.new("\r\n", Regexp.new(/^\{.*\}\r\n$/))
+      json_processor = JsonDataBuffer.new("\r\n", Regexp.new(/^\{.*\}\r\n/))
       @stream = Stream.new(url, json_processor, headers)
     end
   end

--- a/lib/gnip-stream/json_stream.rb
+++ b/lib/gnip-stream/json_stream.rb
@@ -4,7 +4,7 @@ module GnipStream
   class JsonStream
     include StreamDelegate
     def initialize(url, headers={})
-      json_processor = DataBuffer.new(Regexp.new(/^(\{.*\})\s\s(.*)/))
+      json_processor = JsonDataBuffer.new("\r\n", Regexp.new(/^\{.*\}\r\n$/))
       @stream = Stream.new(url, json_processor, headers)
     end
   end

--- a/lib/gnip-stream/xml_data_buffer.rb
+++ b/lib/gnip-stream/xml_data_buffer.rb
@@ -1,5 +1,5 @@
 module GnipStream
-  class DataBuffer 
+  class XmlDataBuffer 
     attr_accessor :pattern
     def initialize(pattern)
       @pattern = pattern

--- a/lib/gnip-stream/xml_stream.rb
+++ b/lib/gnip-stream/xml_stream.rb
@@ -3,7 +3,7 @@ module GnipStream
   class XmlStream
     include StreamDelegate
     def initialize(url, headers={})
-      xml_processor = DataBuffer.new(Regexp.new(/^(\<entry.*?\<\/entry\>)(.*)/m))
+      xml_processor = XmlDataBuffer.new(Regexp.new(/^(\<entry.*?\<\/entry\>)(.*)/m))
       @stream = Stream.new(url, xml_processor, headers)
     end
   end

--- a/spec/gnip-stream/json_data_buffer_spec.rb
+++ b/spec/gnip-stream/json_data_buffer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'gnip-stream/json_data_buffer'
 
 describe GnipStream::JsonDataBuffer do
-  subject { GnipStream::JsonDataBuffer.new("\n", /hello/) }
+  subject { GnipStream::JsonDataBuffer.new("\r\n", Regexp.new(/^.*\r\n/)) }
   describe "#initialize" do
     it "accepts a regex pattern that will be used to match complete entries" do
       split_pattern = "\n"
@@ -14,16 +14,24 @@ describe GnipStream::JsonDataBuffer do
 
   describe "#process" do
     it "appends the data to the buffer" do
-      subject.process("hello\nother")
-      subject.instance_variable_get(:@buffer).should == "hello\nother"
+      subject.process("hello\r\nother")
+      subject.instance_variable_get(:@buffer).should == "hello\r\nother"
     end
   end
 
   describe "#complete_entries" do
     it "returns a list of complete entries" do
-      subject.process("hello\nother")
+      subject.process("hello\r\nother")
       subject.complete_entries.should == ["hello"]
       subject.instance_variable_get(:@buffer).should == "other"
+    end
+  end
+
+  describe "#multiple complete_entries" do
+    it "returns a list of complete entries" do
+      subject.process("hello\r\nhello2\r\nhello3\r\nhel")
+      subject.complete_entries.should == ["hello","hello2","hello3"]
+      subject.instance_variable_get(:@buffer).should == "hel"
     end
   end
 end

--- a/spec/gnip-stream/json_data_buffer_spec.rb
+++ b/spec/gnip-stream/json_data_buffer_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'gnip-stream/json_data_buffer'
+
+describe GnipStream::JsonDataBuffer do
+  subject { GnipStream::JsonDataBuffer.new("\n", /hello/) }
+  describe "#initialize" do
+    it "accepts a regex pattern that will be used to match complete entries" do
+      split_pattern = "\n"
+      check_pattern = Regexp.new(/hello/)
+      GnipStream::JsonDataBuffer.new(split_pattern, check_pattern).check_pattern.should == check_pattern
+      GnipStream::JsonDataBuffer.new(split_pattern, check_pattern).split_pattern.should == split_pattern
+    end
+  end
+
+  describe "#process" do
+    it "appends the data to the buffer" do
+      subject.process("hello\nother")
+      subject.instance_variable_get(:@buffer).should == "hello\nother"
+    end
+  end
+
+  describe "#complete_entries" do
+    it "returns a list of complete entries" do
+      subject.process("hello\nother")
+      subject.complete_entries.should == ["hello"]
+      subject.instance_variable_get(:@buffer).should == "other"
+    end
+  end
+end

--- a/spec/gnip-stream/json_stream_spec.rb
+++ b/spec/gnip-stream/json_stream_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'gnip-stream/json_stream'
+require 'gnip-stream/json_data_buffer'
 
 describe GnipStream::JsonStream do
   subject { GnipStream::JsonStream.new("http://example.com") }

--- a/spec/gnip-stream/xml_data_buffer_spec.rb
+++ b/spec/gnip-stream/xml_data_buffer_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
-require 'gnip-stream/data_buffer'
+require 'gnip-stream/xml_data_buffer'
 
-describe GnipStream::DataBuffer do
-  subject { GnipStream::DataBuffer.new(/(test)(.*)/) }
+describe GnipStream::XmlDataBuffer do
+  subject { GnipStream::XmlDataBuffer.new(/(test)(.*)/) }
   describe "#initialize" do
     it "accepts a regex pattern that will be used to match complete entries" do
       pattern = Regexp.new(/hello/)
-      GnipStream::DataBuffer.new(pattern).pattern.should == pattern
+      GnipStream::XmlDataBuffer.new(pattern).pattern.should == pattern
     end
   end
 


### PR DESCRIPTION
This rewrite was made because I couldn't find out how to build a proper Regex to capture all the data remaining on the chunk to be processed.

If you can find a way for the Regex to work on chunks with multiple activities on it, it should be the correct fix for this.